### PR TITLE
remove toolset

### DIFF
--- a/node/ci-cpp.bat
+++ b/node/ci-cpp.bat
@@ -6,15 +6,12 @@ SET EL=0
 
 ECHO =========== %~f0 ===========
 
-:: only set '--toolset=' if msvs_toolset=14 was explicitly passed in
-IF /I "%msvs_toolset%"=="14" SET TOOLSET=--toolset=v140
 :: default to VS2015
 IF /I "%msvs_toolset%"=="" SET msvs_toolset=14
 SET VCVARSALL=C:\Program Files (x86)\Microsoft Visual Studio %msvs_toolset%.0\VC\vcvarsall.bat
 IF /I "%msvs_toolset%"=="14" SET MSVSVERSION=2015
 IF /I "%msvs_toolset%"=="12" SET MSVSVERSION=2013
 
-ECHO TOOLSET^: %TOOLSET%
 ECHO msvs_toolset^: %msvs_toolset%
 ECHO MSVSVERSION^: %MSVSVERSION%
 ECHO VCVARSALL^: "%VCVARSALL%"
@@ -49,7 +46,7 @@ where npm
 CALL npm -v
 ECHO building ...
 :: --msvs_version=2015 is passed along to node-gyp here
-CALL npm install --build-from-source --msvs_version=%MSVSVERSION% %TOOLSET% --loglevel=http --node_shared=true
+CALL npm install --build-from-source --msvs_version=%MSVSVERSION% --loglevel=http --node_shared=true
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 CALL npm test
 :: comment next line to allow build to work even if tests do not pass
@@ -57,11 +54,11 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO APPVEYOR_REPO_COMMIT_MESSAGE^: %APPVEYOR_REPO_COMMIT_MESSAGE%
 SET CM=%APPVEYOR_REPO_COMMIT_MESSAGE%
 ECHO packaging ...
-CALL node_modules\.bin\node-pre-gyp package %TOOLSET%
+CALL node_modules\.bin\node-pre-gyp package
 IF %ERRORLEVEL% NEQ 0 ECHO error during packaging && GOTO ERROR
-IF NOT "%CM%" == "%CM:[publish binary]=%" (ECHO publishing... && CALL node_modules\.bin\node-pre-gyp publish %TOOLSET%) ELSE (ECHO not publishing)
+IF NOT "%CM%" == "%CM:[publish binary]=%" (ECHO publishing... && CALL node_modules\.bin\node-pre-gyp publish) ELSE (ECHO not publishing)
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF NOT "%CM%" == "%CM:[republish binary]=%" (ECHO republishing ... && CALL node_modules\.bin\node-pre-gyp unpublish publish %TOOLSET%) ELSE (ECHO not republishing)
+IF NOT "%CM%" == "%CM:[republish binary]=%" (ECHO republishing ... && CALL node_modules\.bin\node-pre-gyp unpublish publish) ELSE (ECHO not republishing)
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 GOTO DONE
 :ERROR


### PR DESCRIPTION
This removes the toolset argument in order to:

 - be able to ask for the `svs_toolset=14` toolset without this custom option meaning customly versioned binaries
 - because these custom versioned binaries are no longer needed (they were only needed when building against the node C++11 fork used at https://github.com/mapbox/node-cpp11)